### PR TITLE
Fix SCSS compilation for main stylesheet

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,3 +1,5 @@
+---
+---
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Roboto:wght@400;700&display=swap');
 
 $theme-colors: (


### PR DESCRIPTION
The main stylesheet was not being compiled from SCSS to CSS because `assets/css/main.scss` was missing the necessary YAML front matter. This resulted in a 404 error for `main.css`.

This commit adds the required front matter (`---`) to `assets/css/main.scss` to ensure Jekyll processes the file and generates the `main.css` stylesheet.

I also investigated the issue regarding "Access to storage is not allowed from this context" for `web-client-content-script.js`. This file is not part of your repository, suggesting the error originates from a browser extension or other external script and is not addressable within this codebase.