### PR TITLE
feat: Implement sidebar and reduce header size

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,19 +3,19 @@
     <svg width="24" height="24" viewBox="0 0 24 24"><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>
     <span>Strona Główna</span>
   </a>
-  <a href="#" class="nav-item">
+  <a href="#" class="nav-item" id="btn-kategorie">
     <svg width="24" height="24" viewBox="0 0 24 24"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
     <span>Kategorie</span>
   </a>
-  <a href="#" class="nav-item">
+  <a href="#" class="nav-item" id="btn-szukaj">
     <svg width="24" height="24" viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5A6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
     <span>Szukaj</span>
   </a>
-  <a href="#" class="nav-item">
+  <a href="#" class="nav-item" id="btn-ulubione">
     <svg width="24" height="24" viewBox="0 0 24 24"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
     <span>Ulubione</span>
   </a>
-  <a href="#" class="nav-item">
+  <a href="#" class="nav-item" id="btn-udostepnij">
     <svg width="24" height="24" viewBox="0 0 24 24"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92c0-1.61-1.31-2.92-2.92-2.92z"/></svg>
     <span>Udostępnij</span>
   </a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,7 +10,7 @@
         <li><a href="#">Kontakt</a></li>
         <li {% if page.url == "/about.html" or page.url == "/about/" %}class="active-nav-item"{% endif %}><a href="{{ "/about.html" | relative_url }}">O nas</a></li>
       </ul>
-      <a href="#" class="search-icon">
+      <a href="#" class="search-icon" id="header-search-icon">
         <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" style="vertical-align: middle;">
           <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5A6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
         </svg>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,0 +1,25 @@
+<aside class="sidebar" id="sidebar">
+  <button class="sidebar-close-btn" id="sidebar-close-btn">&times;</button>
+  <div class="sidebar-content" id="sidebar-content">
+    <div id="sidebar-kategorie-content" class="sidebar-section-content" style="display:none;">
+      <h2>Kategorie</h2>
+      <p>Treść dla kategorii...</p>
+    </div>
+    <div id="sidebar-szukaj-content" class="sidebar-section-content" style="display:none;">
+      <h2>Szukaj</h2>
+      <p>Formularz wyszukiwania...</p>
+      <!-- Placeholder for search input -->
+      <input type="search" id="sidebar-search-input" placeholder="Wpisz szukaną frazę...">
+      <div id="sidebar-search-results"></div>
+    </div>
+    <div id="sidebar-ulubione-content" class="sidebar-section-content" style="display:none;">
+      <h2>Ulubione</h2>
+      <p>Lista ulubionych...</p>
+    </div>
+    <div id="sidebar-udostepnij-content" class="sidebar-section-content" style="display:none;">
+      <h2>Udostępnij</h2>
+      <p>Opcje udostępniania...</p>
+    </div>
+  </div>
+</aside>
+<div class="sidebar-overlay" id="sidebar-overlay" style="display:none;"></div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,8 @@
 
     {%- include footer.html -%}
 
+    {%- include sidebar.html -%}
+    <script src="{{ '/assets/js/main.js' | relative_url }}" defer></script>
   </body>
 
 </html>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -164,7 +164,7 @@ hr {
   left: 0;
   right: 0;
   z-index: 1020; // Ensure header is above most content but below critical modals if any
-  padding: 0.75rem 0; // Adjusted padding slightly
+  padding: 0.5rem 0; // Adjusted padding slightly
 
   .wrapper {
     display: flex;
@@ -179,7 +179,7 @@ hr {
 
 .site-title, .site-title:visited {
   color: $text-color; // Use defined $text-color
-  font-size: 1.3em;
+  font-size: 1.1em;
 }
 
 // Remove or comment out old .site-nav if no longer used
@@ -310,7 +310,7 @@ hr {
 
 // --- Layout Adjustments ---
 .page-content {
-  padding-top: 70px; // Adjusted for potentially taller header with new font/padding
+  padding-top: 50px; // Adjusted for potentially taller header with new font/padding
   padding-bottom: 50px; // Adjusted for bottom-navbar height (approx 40-45px + margin)
 
   // On desktop, bottom-navbar is hidden, so padding-bottom can be reduced.
@@ -464,4 +464,103 @@ a.post-card-link {
         max-width: -webkit-calc(100% - (#{$spacing-unit})); // Take more width on small screens
         max-width:         calc(100% - (#{$spacing-unit}));
     }
+}
+
+// --- Sidebar Styles ---
+.sidebar {
+  position: fixed;
+  top: 0;
+  right: -300px; // Initially off-screen
+  width: 300px;
+  height: 100%;
+  background-color: map-get($theme-colors, secondary-bg);
+  box-shadow: 0 0 10px rgba(0,0,0,0.5);
+  z-index: 1040; // Higher than header (1020) and bottom-navbar (1030)
+  transition: right 0.3s ease-in-out;
+  overflow-y: auto;
+  padding: $spacing-unit;
+  color: map-get($theme-colors, primary-text); // Default text color for sidebar
+
+  // Responsive width for smaller screens
+  @media screen and (max-width: $on-palm) { // Assuming $on-palm is around 600px
+    width: 80%;
+    right: -80%; // Adjust initial off-screen position
+  }
+
+  &.open {
+    right: 0;
+  }
+}
+
+.sidebar-close-btn {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  background: transparent;
+  border: none;
+  color: map-get($theme-colors, primary-text);
+  font-size: 24px;
+  cursor: pointer;
+
+  &:hover {
+    color: map-get($theme-colors, link-hover-color);
+  }
+}
+
+.sidebar-content {
+  // General styling for content if needed, e.g., margin-top after considering close button
+  margin-top: 20px; // Example: to give some space below the close button area
+
+  h2 {
+    color: map-get($theme-colors, accent-color); // Use accent color for headings
+    margin-top: $spacing-unit;
+    margin-bottom: $spacing-unit / 2;
+    &:first-child {
+      margin-top: 0; // No top margin for the first heading in a section
+    }
+  }
+
+  p {
+    line-height: 1.6;
+    margin-bottom: $spacing-unit / 2;
+  }
+
+  // Styling for the search input in sidebar
+  #sidebar-search-input {
+    width: 100%;
+    padding: 10px;
+    margin-bottom: $spacing-unit / 2;
+    border: 1px solid darken(map-get($theme-colors, secondary-bg), 10%);
+    background-color: map-get($theme-colors, primary-bg);
+    color: map-get($theme-colors, primary-text);
+    border-radius: 4px;
+  }
+
+  #sidebar-search-results {
+    // Styles for search results container
+    margin-top: $spacing-unit / 2;
+    // Example:
+    // a { display: block; padding: 5px 0; }
+  }
+}
+
+.sidebar-section-content {
+  display: none; // Hidden by default, JS will manage visibility
+  // Add any common styling for all sections if needed
+}
+
+// --- Sidebar Overlay ---
+.sidebar-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  z-index: 1035; // Below sidebar (1040), above header (1020) and bottom-navbar (1030)
+  display: none; // Initially hidden
+
+  &.active {
+    display: block;
+  }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,116 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const sidebar = document.getElementById('sidebar');
+  const sidebarContent = document.getElementById('sidebar-content'); // Though not directly manipulated in this plan, good to have.
+  const sidebarCloseBtn = document.getElementById('sidebar-close-btn');
+  const sidebarOverlay = document.getElementById('sidebar-overlay');
+
+  // Content sections
+  const kategorieContent = document.getElementById('sidebar-kategorie-content');
+  const szukajContent = document.getElementById('sidebar-szukaj-content');
+  const ulubioneContent = document.getElementById('sidebar-ulubione-content');
+  const udostepnijContent = document.getElementById('sidebar-udostepnij-content');
+
+  const allSidebarSections = document.querySelectorAll('.sidebar-section-content');
+
+  // Bottom navigation buttons (using anticipated IDs)
+  const btnKategorie = document.getElementById('btn-kategorie');
+  const btnSzukaj = document.getElementById('btn-szukaj'); // This is also the search icon in the header.
+  const btnUlubione = document.getElementById('btn-ulubione');
+  const btnUdostepnij = document.getElementById('btn-udostepnij');
+
+  // Header search icon
+  const headerSearchIcon = document.getElementById('header-search-icon');
+
+
+  function openSidebar(contentType) {
+    if (!sidebar) return;
+
+    // Hide all sections first
+    allSidebarSections.forEach(section => {
+      section.style.display = 'none';
+    });
+
+    // Show the target section
+    let targetSection;
+    switch (contentType) {
+      case 'kategorie':
+        targetSection = kategorieContent;
+        break;
+      case 'szukaj':
+        targetSection = szukajContent;
+        break;
+      case 'ulubione':
+        targetSection = ulubioneContent;
+        break;
+      case 'udostepnij':
+        targetSection = udostepnijContent;
+        break;
+      default:
+        console.warn('Unknown content type:', contentType);
+        return;
+    }
+
+    if (targetSection) {
+      targetSection.style.display = 'block';
+    }
+
+    sidebar.classList.add('open');
+    if (sidebarOverlay) {
+      sidebarOverlay.classList.add('active'); // Using class for consistency with CSS
+    }
+  }
+
+  function closeSidebar() {
+    if (!sidebar) return;
+    sidebar.classList.remove('open');
+    if (sidebarOverlay) {
+      sidebarOverlay.classList.remove('active'); // Using class
+    }
+  }
+
+  // Event Listeners
+  if (sidebarCloseBtn) {
+    sidebarCloseBtn.addEventListener('click', closeSidebar);
+  }
+
+  if (sidebarOverlay) {
+    sidebarOverlay.addEventListener('click', closeSidebar);
+  }
+
+  // Bottom navigation button listeners
+  if (btnKategorie) {
+    btnKategorie.addEventListener('click', (event) => {
+      event.preventDefault();
+      openSidebar('kategorie');
+    });
+  }
+
+  if (btnSzukaj) {
+    btnSzukaj.addEventListener('click', (event) => {
+      event.preventDefault();
+      openSidebar('szukaj');
+    });
+  }
+
+  if (headerSearchIcon) {
+    headerSearchIcon.addEventListener('click', (event) => {
+      event.preventDefault();
+      openSidebar('szukaj');
+    });
+  }
+
+  if (btnUlubione) {
+    btnUlubione.addEventListener('click', (event) => {
+      event.preventDefault();
+      openSidebar('ulubione');
+    });
+  }
+
+  if (btnUdostepnij) {
+    btnUdostepnij.addEventListener('click', (event) => {
+      event.preventDefault();
+      openSidebar('udostepnij');
+    });
+  }
+
+});


### PR DESCRIPTION
This commit introduces a new sidebar feature and visual adjustments:

1.  **Header Size Reduction:**
    *   Decreased padding in the main header.
    *   Reduced font size for the site title.
    *   Adjusted page content top padding to match the new header height.

2.  **Sidebar Implementation:**
    *   Added HTML structure for a sidebar (`_includes/sidebar.html`) which is included in the default layout.
    *   The sidebar includes sections for "Kategorie", "Szukaj", "Ulubione", and "Udostępnij", initially populated with placeholder content.
    *   Styled the sidebar (and an accompanying overlay) using CSS in `assets/css/main.scss`. It's positioned off-screen by default and slides in.
    *   Created `assets/js/main.js` to handle sidebar toggling:
        *   Opening the sidebar and displaying content relevant to the clicked button.
        *   Closing the sidebar via a close button or by clicking the overlay.

3.  **Button Functionality:**
    *   Updated buttons in the bottom navigation bar (`_includes/footer.html`) with unique IDs. These buttons now trigger the sidebar to open, displaying the corresponding content section (e.g., "Kategorie" button opens the "Kategorie" section in the sidebar).
    *   The "Strona Główna" button retains its original navigation functionality.
    *   The search icon in the header (`_includes/header.html`) now also triggers the "Szukaj" section in the sidebar.

These changes address your request for a smaller header and functional bottom bar buttons that open a sidebar with appropriate content.