### PR TITLE
feat: Implement LLM-powered discussion-to-blog pipeline

### DIFF
--- a/.github/workflows/sync_discussions_workflow.yml
+++ b/.github/workflows/sync_discussions_workflow.yml
@@ -1,0 +1,52 @@
+name: Sync Discussion to Blog Post
+
+on:
+  discussion:
+    types: [created, edited]
+
+jobs:
+  sync_and_publish:
+    # Only run if the discussion is in a specific category (e.g., 'News', 'Blog Posts')
+    # IMPORTANT: User needs to update 'YOUR_DISCUSSION_CATEGORY' to their desired category name.
+    # If the category name has spaces, it should be enclosed in quotes.
+    if: github.event.discussion.category.name == 'YOUR_DISCUSSION_CATEGORY'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to commit changes back to the repo
+      discussions: read # Required to read discussion content (already specified for PAT)
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x' # Use a recent Python 3 version
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests PyYAML google-generativeai
+
+      - name: Run Sync Script
+        env:
+          # GITHUB_REPO is automatically set by Actions
+          # GITHUB_TOKEN: Using GH_PAT as per user's setup for script's GraphQL calls
+          GH_PAT: ${{ secrets.GH_PAT }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GITHUB_DISCUSSION_ID: ${{ github.event.discussion.node_id }}
+          GITHUB_DISCUSSION_CATEGORY_NAME: ${{ github.event.discussion.category.name }}
+        run: python sync_discussions.py
+
+      - name: Commit and Push Blog Post
+        run: |
+          git config --global user.name 'GitHub Actions Bot'
+          git config --global user.email 'actions-bot@users.noreply.github.com'
+          # Check if there are changes in _posts/
+          if ! git diff --quiet _posts/; then
+            git add _posts/*.md
+            git commit -m "Automated: Add/update blog post from discussion '${{ github.event.discussion.title }}'"
+            git push
+          else
+            echo "No changes to commit in _posts/ directory."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,26 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+ENV/
+VENV/
+.venv/
+pip-log.txt
+pip-delete-this-directory.txt
+.tox/
+.nox/
+.hypothesis/
+.pytest_cache/
+coverage.xml
+htmlcov/
+*.egg-info/
+.installed.cfg
+*.egg

--- a/sync_discussions.py
+++ b/sync_discussions.py
@@ -1,0 +1,206 @@
+import os
+import requests
+import yaml
+from datetime import datetime
+import google.generativeai as genai
+import re # Import regex for sanitizing filenames
+
+# --- Configuration from Environment Variables ---
+# The GITHUB_REPO variable will be automatically set by GitHub Actions if running in the same repo
+# Otherwise, you might need to manually set it if discussions are in a different repo
+REPO_OWNER, REPO_NAME = os.environ.get('GITHUB_REPO').split('/')
+GITHUB_TOKEN = os.environ.get('GH_PAT') # MODIFIED: Changed from GITHUB_TOKEN to GH_PAT
+GEMINI_API_KEY = os.environ.get('GEMINI_API_KEY')
+GEMINI_MODEL_NAME = "gemini-1.5-flash" # Recommended for speed and cost-effectiveness
+# Consider "gemini-1.5-pro" for higher quality but potentially higher cost/latency
+
+# --- New: Get the specific discussion ID from environment variable ---
+# This ID comes from the GitHub Actions event payload
+TARGET_DISCUSSION_ID = os.environ.get('GITHUB_DISCUSSION_ID')
+if not TARGET_DISCUSSION_ID:
+    print("Error: GITHUB_DISCUSSION_ID environment variable not set. This script requires a target discussion ID.")
+    # Exit gracefully if the expected environment variable is not found
+    exit(1)
+
+# --- Setup Gemini ---
+try:
+    genai.configure(api_key=GEMINI_API_KEY)
+    model = genai.GenerativeModel(GEMINI_MODEL_NAME)
+except Exception as e:
+    print(f"Error configuring Gemini API: {e}")
+    # Exit if Gemini API setup fails, as it's critical for the script
+    exit(1)
+
+# --- GitHub API Setup ---
+GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+HEADERS = {
+    'Authorization': f'token {GITHUB_TOKEN}', # This will now use GH_PAT
+    'Content-Type': 'application/json',
+}
+
+def get_single_discussion(discussion_node_id):
+    """
+    Fetches a single GitHub Discussion by its GraphQL Node ID.
+    This uses the GitHub GraphQL API to get detailed information about the discussion.
+    """
+    query = """
+    query($nodeId: ID!) {
+      node(id: $nodeId) {
+        ... on Discussion {
+          id
+          title
+          url
+          createdAt
+          lastEditedAt
+          bodyHTML # Use bodyHTML if you want HTML content to be processed by LLM
+                   # Use 'body' if you want raw Markdown
+          category {
+            name
+          }
+          author {
+            login
+          }
+          # You could also fetch comments here if you want LLM to process them
+          # For simplicity, we are only processing the initial discussion body
+        }
+      }
+    }
+    """
+    variables = {"nodeId": discussion_node_id}
+    try:
+        response = requests.post(GITHUB_GRAPHQL_URL, headers=HEADERS, json={'query': query, 'variables': variables})
+        response.raise_for_status() # Raise an exception for HTTP errors
+        data = response.json()
+        return data['data']['node']
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching discussion from GitHub API: {e}")
+        return None
+    except KeyError:
+        print(f"Unexpected response structure from GitHub API for discussion ID: {discussion_node_id}")
+        return None
+
+
+def generate_blog_post_with_gemini(discussion_title, discussion_body, discussion_category):
+    """
+    Uses the Gemini LLM to transform the GitHub Discussion content into a blog post.
+    The prompt is crucial here for guiding the LLM's output.
+    """
+    prompt = f"""
+    You are an AI assistant tasked with converting GitHub Discussions into concise and engaging blog posts for a news site.
+
+    Please take the following GitHub Discussion and reformat it into a blog post suitable for a technical news site.
+    Focus on clarity, conciseness, and making it engaging for a general audience interested in tech news.
+    You can expand on points, rephrase for better flow, and summarize lengthy sections.
+    The output should be primarily the blog post content in Markdown format, ready to be embedded.
+    Ensure the generated content is well-structured with headings and paragraphs if appropriate.
+    Do NOT include YAML front matter.
+    Do NOT include any introductory or concluding remarks outside the blog post content itself (e.g., "Here is your blog post:").
+    Do NOT include code blocks or triple backticks unless they are part of the actual blog post content.
+
+    GitHub Discussion Title: "{discussion_title}"
+    GitHub Discussion Category: "{discussion_category}"
+
+    GitHub Discussion Body:
+    ```
+    {discussion_body}
+    ```
+
+    Please generate the blog post content below:
+    """
+    print(f"Sending prompt to Gemini for discussion: '{discussion_title}'")
+    try:
+        # Fetch the response from the Gemini API
+        response = model.generate_content(prompt)
+        # Check if candidates and content exist before accessing text
+        if response.candidates and response.candidates[0].content and response.candidates[0].content.parts:
+            return response.candidates[0].content.parts[0].text
+        else:
+            print(f"Gemini API returned no content for discussion: '{discussion_title}'")
+            return f"**Error: Gemini API returned no content for this discussion.**\n\nOriginal Discussion:\n\n{discussion_body}"
+    except Exception as e:
+        print(f"Error calling Gemini API for discussion '{discussion_title}': {e}")
+        return f"**Error: Could not generate content for this discussion using Gemini.**\n\nOriginal Discussion:\n\n{discussion_body}"
+
+def sanitize_filename(title):
+    """
+    Sanitizes a string to be suitable for a filename.
+    Removes invalid characters and replaces spaces with hyphens.
+    """
+    # Replace spaces with hyphens
+    s = title.replace(" ", "-")
+    # Remove any characters that are not alphanumeric, hyphens, or underscores
+    s = re.sub(r'[^\w-]', '', s)
+    # Remove multiple consecutive hyphens
+    s = re.sub(r'-+', '-', s)
+    # Trim hyphens from start/end
+    s = s.strip('-')
+    return s
+
+def main():
+    # Attempt to fetch the target discussion
+    discussion = get_single_discussion(TARGET_DISCUSSION_ID)
+    if not discussion:
+        print(f"Skipping post creation for discussion ID: {TARGET_DISCUSSION_ID} (not found or error during fetch).")
+        return # Exit if the discussion couldn't be fetched
+
+    posts_dir = '_posts'
+    # Ensure the _posts directory exists
+    os.makedirs(posts_dir, exist_ok=True)
+
+    discussion_id = discussion['id']
+    title = discussion['title']
+    body = discussion['bodyHTML'] # Use 'body' if you want raw Markdown
+    created_at_str = discussion['createdAt']
+    category = discussion['category']['name'] if discussion['category'] else "Uncategorized"
+    author = discussion['author']['login'] if discussion['author'] else "Unknown Author"
+    last_edited_at_str = discussion.get('lastEditedAt', created_at_str) # Use edited date if available
+
+    # Format the date for the filename
+    filename_date = datetime.strptime(created_at_str, '%Y-%m-%dT%H:%M:%SZ').strftime('%Y-%m-%d')
+    # Sanitize the title for use in the filename
+    sanitized_title = sanitize_filename(title)
+    if not sanitized_title: # Fallback if sanitization results in an empty string
+        sanitized_title = f"discussion-{discussion_id[:8]}"
+
+    # Construct the full filepath for the Jekyll post
+    filepath = os.path.join(posts_dir, f"{filename_date}-{sanitized_title}.md")
+
+    print(f"Processing discussion: '{title}' (ID: {discussion_id})")
+
+    # Call Gemini for content generation
+    blog_content = generate_blog_post_with_gemini(title, body, category)
+
+    # Format dates for Jekyll front matter
+    jekyll_created_date = datetime.strptime(created_at_str, '%Y-%m-%dT%H:%M:%SZ').strftime('%Y-%m-%d %H:%M:%S %z')
+    jekyll_edited_date = datetime.strptime(last_edited_at_str, '%Y-%m-%dT%H:%M:%SZ').strftime('%Y-%m-%d %H:%M:%S %z')
+
+
+    # Prepare Jekyll front matter
+    front_matter = {
+        'layout': 'post', # Assuming you have a 'post' layout in your Jekyll theme
+        'title': title,
+        'date': jekyll_created_date,
+        'categories': [category], # Using the discussion category as a Jekyll category
+        'author': author,
+        'github_discussion_url': discussion['url'],
+        'github_discussion_id': discussion_id,
+        'github_last_edited_at': jekyll_edited_date, # Useful for idempotency checks or display
+        'llm_processed': True # Flag to indicate LLM processing
+    }
+
+    # Write the Jekyll post file
+    try:
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write('---\n')
+            # Dump the front matter into YAML format
+            yaml.dump(front_matter, f, allow_unicode=True, default_flow_style=False)
+            f.write('---\n\n')
+            f.write(blog_content) # Write the LLM-generated content
+        print(f"Successfully generated/updated post: {filepath}")
+    except IOError as e:
+        print(f"Error writing post file '{filepath}': {e}")
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit introduces a system to automatically convert GitHub Discussions into Jekyll blog posts using a Python script and the Gemini LLM, orchestrated by GitHub Actions.

Key changes:

1.  **Added `sync_discussions.py`:**
    *   This script fetches a target GitHub Discussion using its Node ID.
    *   It uses the Gemini LLM to transform the discussion's content (title, body, category) into a blog post format.
    *   The script generates a Markdown file with appropriate Jekyll front matter (layout, title, date, categories, author, discussion URL, etc.) in the `_posts` directory.
    *   It sanitizes discussion titles for use in filenames.
    *   The script is configured to use `GH_PAT` and `GEMINI_API_KEY` from environment variables for authentication and LLM access.

2.  **Added GitHub Actions Workflow (`.github/workflows/sync_discussions_workflow.yml`):**
    *   Triggers when a discussion is created or edited.
    *   IMPORTANT: The workflow is currently set to trigger for discussions in a category named 'YOUR_DISCUSSION_CATEGORY'. You must update this to your specific target category.
    *   Sets up a Python environment and installs dependencies (`requests`, `PyYAML`, `google-generativeai`).
    *   Runs `sync_discussions.py`, passing necessary secrets and event data (discussion ID, category name).
    *   Commits and pushes the generated/updated blog post file to the `_posts` directory.
    *   Requires `GH_PAT` and `GEMINI_API_KEY` secrets to be set in the repository.

3.  **Updated `.gitignore`:**
    *   Added common Python ignore patterns (e.g., `__pycache__`, `*.pyc`, `venv/`) to prevent these files from being tracked.

This setup allows for automated content generation from discussions, streamlining the process of creating a news site based on community interactions.