### PR TITLE
feat: Summarize discussion comments into blog posts

### DIFF
--- a/.github/workflows/sync_discussions_workflow.yml
+++ b/.github/workflows/sync_discussions_workflow.yml
@@ -3,6 +3,8 @@ name: Sync Discussion to Blog Post
 on:
   discussion:
     types: [created, edited]
+  discussion_comment:
+    types: [created]
 
 jobs:
   sync_and_publish:
@@ -27,14 +29,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install requests PyYAML google-generativeai
 
+      - name: Set Discussion Node ID
+        id: set_discussion_id
+        run: |
+          if [[ "${{ github.event_name }}" == "discussion" ]]; then
+            echo "DISCUSSION_NODE_ID=${{ github.event.discussion.node_id }}" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == "discussion_comment" ]]; then
+            echo "DISCUSSION_NODE_ID=${{ github.event.comment.discussion.node_id }}" >> $GITHUB_ENV
+          fi
       - name: Run Sync Script
         env:
-          # GITHUB_REPO is automatically set by Actions
-          # GITHUB_TOKEN: Using GH_PAT as per user's setup for script's GraphQL calls
           GH_PAT: ${{ secrets.GH_PAT }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GITHUB_DISCUSSION_ID: ${{ github.event.discussion.node_id }}
-          GITHUB_DISCUSSION_CATEGORY_NAME: ${{ github.event.discussion.category.name }}
+          GITHUB_DISCUSSION_ID: ${{ env.DISCUSSION_NODE_ID }}
         run: python sync_discussions.py
 
       - name: Commit and Push Blog Post

--- a/sync_discussions.py
+++ b/sync_discussions.py
@@ -60,8 +60,15 @@ def get_single_discussion(discussion_node_id):
           author {
             login
           }
-          # You could also fetch comments here if you want LLM to process them
-          # For simplicity, we are only processing the initial discussion body
+          comments(first: 100) { # Fetching first 100 comments
+            nodes {
+              bodyHTML
+              createdAt
+              author {
+                login
+              }
+            }
+          }
         }
       }
     }
@@ -80,29 +87,31 @@ def get_single_discussion(discussion_node_id):
         return None
 
 
-def generate_blog_post_with_gemini(discussion_title, discussion_body, discussion_category):
+def generate_blog_post_with_gemini(discussion_title, combined_content, discussion_category):
     """
     Uses the Gemini LLM to transform the GitHub Discussion content into a blog post.
     The prompt is crucial here for guiding the LLM's output.
     """
     prompt = f"""
-    You are an AI assistant tasked with converting GitHub Discussions into concise and engaging blog posts for a news site.
+    You are an AI assistant tasked with synthesizing GitHub Discussions and their comments into comprehensive and engaging blog posts for a news site.
 
-    Please take the following GitHub Discussion and reformat it into a blog post suitable for a technical news site.
+    Please take the following GitHub Discussion (which includes the original post and subsequent comments) and transform it into a single, cohesive blog post.
+    The goal is to create a well-rounded article that summarizes the entire conversation, including the main points from the initial discussion and key insights or differing opinions from the comments.
     Focus on clarity, conciseness, and making it engaging for a general audience interested in tech news.
     You can expand on points, rephrase for better flow, and summarize lengthy sections.
-    The output should be primarily the blog post content in Markdown format, ready to be embedded.
-    Ensure the generated content is well-structured with headings and paragraphs if appropriate.
+    Acknowledge differing opinions if they are significant, but generally avoid mentioning specific user names unless critically important for context (and prefer generic attributions like "some users suggested...").
+    The output should be *only* the blog post content in Markdown format, ready to be embedded.
+    Ensure the generated content is well-structured with appropriate headings and paragraphs.
     Do NOT include YAML front matter.
     Do NOT include any introductory or concluding remarks outside the blog post content itself (e.g., "Here is your blog post:").
-    Do NOT include code blocks or triple backticks unless they are part of the actual blog post content.
+    Do NOT include code blocks or triple backticks unless they are essential for the blog post's content.
 
     GitHub Discussion Title: "{discussion_title}"
     GitHub Discussion Category: "{discussion_category}"
 
-    GitHub Discussion Body:
+    Full Discussion Content (Original Post and Comments):
     ```
-    {discussion_body}
+    {combined_content}
     ```
 
     Please generate the blog post content below:
@@ -116,10 +125,10 @@ def generate_blog_post_with_gemini(discussion_title, discussion_body, discussion
             return response.candidates[0].content.parts[0].text
         else:
             print(f"Gemini API returned no content for discussion: '{discussion_title}'")
-            return f"**Error: Gemini API returned no content for this discussion.**\n\nOriginal Discussion:\n\n{discussion_body}"
+            return f"**Error: Gemini API returned no content for this discussion.**\n\nOriginal Discussion:\n\n{combined_content}"
     except Exception as e:
         print(f"Error calling Gemini API for discussion '{discussion_title}': {e}")
-        return f"**Error: Could not generate content for this discussion using Gemini.**\n\nOriginal Discussion:\n\n{discussion_body}"
+        return f"**Error: Could not generate content for this discussion using Gemini.**\n\nOriginal Discussion:\n\n{combined_content}"
 
 def sanitize_filename(title):
     """
@@ -149,11 +158,24 @@ def main():
 
     discussion_id = discussion['id']
     title = discussion['title']
-    body = discussion['bodyHTML'] # Use 'body' if you want raw Markdown
+    # body = discussion['bodyHTML'] # Old way
     created_at_str = discussion['createdAt']
     category = discussion['category']['name'] if discussion['category'] else "Uncategorized"
     author = discussion['author']['login'] if discussion['author'] else "Unknown Author"
     last_edited_at_str = discussion.get('lastEditedAt', created_at_str) # Use edited date if available
+
+    # --- Construct combined content ---
+    original_body = discussion['bodyHTML']
+    combined_content = original_body
+
+    if discussion.get('comments') and discussion['comments'].get('nodes'):
+        combined_content += "\n\n--- Comments ---" # Add a header for comments section
+        for comment in discussion['comments']['nodes']:
+            comment_author = comment.get('author').get('login') if comment.get('author') else 'Unknown User'
+            comment_date = comment.get('createdAt', 'Unknown Date')
+            comment_body = comment.get('bodyHTML', '')
+            # Providing author & date for LLM's context; LLM is instructed not to usually mention users.
+            combined_content += f"\n\n**Comment by {comment_author} on {comment_date}:**\n{comment_body}"
 
     # Format the date for the filename
     filename_date = datetime.strptime(created_at_str, '%Y-%m-%dT%H:%M:%SZ').strftime('%Y-%m-%d')
@@ -165,10 +187,10 @@ def main():
     # Construct the full filepath for the Jekyll post
     filepath = os.path.join(posts_dir, f"{filename_date}-{sanitized_title}.md")
 
-    print(f"Processing discussion: '{title}' (ID: {discussion_id})")
+    print(f"Processing discussion: '{title}' (ID: {discussion_id}) with comments.")
 
-    # Call Gemini for content generation
-    blog_content = generate_blog_post_with_gemini(title, body, category)
+    # Call Gemini for content generation with combined content
+    blog_content = generate_blog_post_with_gemini(title, combined_content, category)
 
     # Format dates for Jekyll front matter
     jekyll_created_date = datetime.strptime(created_at_str, '%Y-%m-%dT%H:%M:%SZ').strftime('%Y-%m-%d %H:%M:%S %z')


### PR DESCRIPTION
This commit enhances the discussion-to-blog functionality to include comments, providing a comprehensive summary of the entire conversation.

Key changes:

1.  **GitHub Actions Workflow (`.github/workflows/sync_discussions_workflow.yml`):**
    *   The workflow now triggers on new discussion comments (`discussion_comment: types: [created]`) in addition to discussion creation and edits (`discussion: types: [created, edited]`).
    *   Updated logic to correctly determine and pass the parent `GITHUB_DISCUSSION_ID` to the Python script, regardless of whether the trigger was a discussion event or a comment event.

2.  **Python Script (`sync_discussions.py`):**
    *   **Data Fetching:**
        *   The `get_single_discussion` GraphQL query now fetches the first 100 comments (including their body, author, and creation date) associated with the discussion.
    *   **Content Processing:**
        *   The `main` function now constructs a `combined_content` string. This string starts with the original discussion's bodyHTML and appends each comment's bodyHTML, along with author and date for context.
    *   **LLM Prompt:**
        *   The `generate_blog_post_with_gemini` function's prompt has been updated. It now instructs the Gemini LLM to synthesize the entire `combined_content` (original post + comments) into a single, cohesive blog post.
        *   The LLM is guided to summarize the overall conversation, acknowledge differing opinions if significant, and generally avoid direct attribution to users, focusing on the collective information.

This update ensures that the generated blog posts are more holistic, capturing the full context of the discussion including valuable insights and interactions from the comments section.