### PR TITLE
Refactor: Use GH_REPO env var for repository path

### DIFF
--- a/sync_discussions.py
+++ b/sync_discussions.py
@@ -6,9 +6,13 @@ import google.generativeai as genai
 import re # Import regex for sanitizing filenames
 
 # --- Configuration from Environment Variables ---
-# The GITHUB_REPO variable will be automatically set by GitHub Actions if running in the same repo
+# The GH_REPO variable will be automatically set by GitHub Actions if running in the same repo
 # Otherwise, you might need to manually set it if discussions are in a different repo
-REPO_OWNER, REPO_NAME = os.environ.get('GITHUB_REPO').split('/')
+github_repo_env = os.environ.get('GH_REPO')
+if github_repo_env is None:
+    print("Error: GH_REPO environment variable not set. This script requires the GH_REPO environment variable to be set in the format OWNER/REPOSITORY_NAME.")
+    exit(1)
+REPO_OWNER, REPO_NAME = github_repo_env.split('/')
 GITHUB_TOKEN = os.environ.get('GH_PAT') # MODIFIED: Changed from GITHUB_TOKEN to GH_PAT
 GEMINI_API_KEY = os.environ.get('GEMINI_API_KEY')
 GEMINI_MODEL_NAME = "gemini-1.5-flash" # Recommended for speed and cost-effectiveness


### PR DESCRIPTION
I changed the script to use GH_REPO instead of GITHUB_REPO for specifying the 'OWNER/REPOSITORY_NAME'.

This change allows you to define the repository path using a variable name that doesn't conflict with the GITHUB_ prefix restriction for secrets when set manually or in certain CI environments.

The error message for the missing variable has also been updated to reflect this change.