### PR TITLE
Fix: Ensure sidebar closes completely by applying border-box sizing

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -480,6 +480,7 @@ a.post-card-link {
   overflow-y: auto;
   padding: $spacing-unit;
   color: map-get($theme-colors, primary-text); // Default text color for sidebar
+  box-sizing: border-box; // <--- Add this line
 
   // Responsive width for smaller screens
   @media screen and (max-width: $on-palm) { // Assuming $on-palm is around 600px


### PR DESCRIPTION
The sidebar was not closing fully because its `width` property did not account for its `padding`. This meant that when it was moved off-screen using `right: -<width>`, the padding area remained visible.

This commit adds `box-sizing: border-box;` to the `.sidebar` CSS rule. This ensures that the `padding` (and any `border`) is included within the sidebar's defined `width`, rather than added to it. As a result, when the sidebar's `right` property is set to the negative of its `width` (e.g., `right: -300px` for a `width: 300px` sidebar), it will now move completely off-screen.