### PR TITLE
Feat: Add dynamic category buttons to bottom navbar

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,10 +3,17 @@
     <svg width="24" height="24" viewBox="0 0 24 24"><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>
     <span>Strona Główna</span>
   </a>
-  <a href="#" class="nav-item" id="btn-kategorie">
+  <!-- <a href="#" class="nav-item" id="btn-kategorie">
     <svg width="24" height="24" viewBox="0 0 24 24"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
     <span>Kategorie</span>
-  </a>
+  </a> -->
+  {% assign categories_to_display = "Ankiety|Blog|Na luzie|Ogłoszenia|Porady|Recenzje|Wiadomości" | split: "|" %}
+  {% for category_name in categories_to_display %}
+    <a href="{{ site.baseurl }}/categories/{{ category_name | slugify }}/" class="nav-item">
+      <svg width="24" height="24" viewBox="0 0 24 24"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
+      <span>{{ category_name }}</span>
+    </a>
+  {% endfor %}
   <a href="#" class="nav-item" id="btn-szukaj">
     <svg width="24" height="24" viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5A6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
     <span>Szukaj</span>


### PR DESCRIPTION
Replaces the static 'Kategorie' button in the bottom navbar with a dynamically generated list of category buttons.

The following categories are now displayed as individual buttons:
- Ankiety
- Blog
- Na luzie
- Ogłoszenia
- Porady
- Recenzje
- Wiadomości

Each button links to the corresponding Jekyll category page (e.g., /categories/blog/) and reuses the original SVG icon from the 'Kategorie' button for visual consistency.

The original 'Kategorie' button has been commented out in _includes/footer.html.